### PR TITLE
chore: upgrade go version from 1.20 to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/pinnacles/torm
 
-go 1.20
+go 1.21
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hatajoe/ttools v0.0.11
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/sirupsen/logrus v1.8.1
@@ -12,7 +11,6 @@ require (
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/shogo82148/go-sql-proxy v0.6.1 // indirect
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hatajoe/ttools v0.0.11 h1:W/9AMRS/wrXkaqvRTGyZgyZs+2SbzhRa0B/hvdMVE44=
 github.com/hatajoe/ttools v0.0.11/go.mod h1:zQehM8OPEL7Q+2EpJ5W86eKhZ/tgxgyFqWfnXZZHzc4=
 github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=

--- a/transaction.go
+++ b/transaction.go
@@ -1,9 +1,9 @@
 package torm
 
 import (
+	"errors"
 	"fmt"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -15,7 +15,7 @@ func Transaction(sql *sqlx.DB, proc Proc) (err error) {
 	defer func() {
 		if err != nil && tx != nil {
 			if e := tx.Rollback(); e != nil {
-				err = multierror.Append(err, fmt.Errorf("failed to rollback transaction: %v", e))
+				err = errors.Join(err, fmt.Errorf("failed to rollback transaction: %v", e))
 			}
 		}
 	}()


### PR DESCRIPTION
- go version を 1.20 から 1.21 へアップグレード
- hashicorp/go-multierror から標準の error package に変更