### PR TITLE
feat: use beginxx for tracing

### DIFF
--- a/examples/transaction/main.go
+++ b/examples/transaction/main.go
@@ -6,10 +6,9 @@ import (
 	"log"
 
 	tsql "github.com/hatajoe/ttools/driver/sql"
+	_ "github.com/hatajoe/ttools/driver/sql/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/pinnacles/torm"
-
-	_ "github.com/hatajoe/ttools/driver/sql/mysql"
 )
 
 var (
@@ -44,7 +43,7 @@ func main() {
 
 	builder := torm.NewBuilder(db)
 
-	must(torm.Transaction(db, func(tx *sqlx.Tx) error {
+	must(torm.Transaction(context.Background(), nil, db, func(tx *sqlx.Tx) error {
 		builder := torm.NewBuilder(tx)
 		must(insertUser(builder))
 		must(insertUsers(builder))
@@ -52,7 +51,7 @@ func main() {
 	}))
 	must(printUsers(builder))
 
-	must(torm.Transaction(db, func(tx *sqlx.Tx) error {
+	must(torm.Transaction(context.Background(), nil, db, func(tx *sqlx.Tx) error {
 		builder := torm.NewBuilder(tx)
 		must(updateUser(builder))
 		must(updateUsers(builder))
@@ -60,7 +59,7 @@ func main() {
 	}))
 	must(printUsers(builder))
 
-	must(torm.Transaction(db, func(tx *sqlx.Tx) error {
+	must(torm.Transaction(context.Background(), nil, db, func(tx *sqlx.Tx) error {
 		builder := torm.NewBuilder(tx)
 		must(deleteUser(builder))
 		must(deleteUsers(builder))

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.21
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/hatajoe/ttools v0.0.11
-	github.com/jmoiron/sqlx v1.3.4
+	github.com/jmoiron/sqlx v1.3.5
 	github.com/sirupsen/logrus v1.8.1
 )
 
 require (
-	github.com/go-sql-driver/mysql v1.5.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/shogo82148/go-sql-proxy v0.6.1 // indirect
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,13 @@ github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBK
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/hatajoe/ttools v0.0.11 h1:W/9AMRS/wrXkaqvRTGyZgyZs+2SbzhRa0B/hvdMVE44=
 github.com/hatajoe/ttools v0.0.11/go.mod h1:zQehM8OPEL7Q+2EpJ5W86eKhZ/tgxgyFqWfnXZZHzc4=
-github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
-github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
+github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
+github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.14.1/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=

--- a/transaction.go
+++ b/transaction.go
@@ -1,6 +1,8 @@
 package torm
 
 import (
+	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -9,7 +11,7 @@ import (
 
 type Proc func(*sqlx.Tx) error
 
-func Transaction(sql *sqlx.DB, proc Proc) (err error) {
+func Transaction(ctx context.Context, opts *sql.TxOptions, sql *sqlx.DB, proc Proc) (err error) {
 	var tx *sqlx.Tx
 
 	defer func() {
@@ -20,7 +22,7 @@ func Transaction(sql *sqlx.DB, proc Proc) (err error) {
 		}
 	}()
 
-	tx, err = sql.Beginx()
+	tx, err = sql.BeginTxx(ctx, opts)
 	if err != nil {
 		return
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -18,7 +18,7 @@ func TestTransactionCommit(t *testing.T) {
 		mock.ExpectExec("INSERT INTO `test`").WithArgs(1, tm, tm).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectCommit()
 
-		if err := Transaction(db, func(tx *sqlx.Tx) error {
+		if err := Transaction(context.Background(), nil, db, func(tx *sqlx.Tx) error {
 			builder := NewBuilder(tx)
 			builder.SetTime(&tm)
 			_, err := builder.Insert().Exec(ctx, &test.TestSchema{Foo: 1, Bar: 2})
@@ -41,7 +41,7 @@ func TestTransactionRollback(t *testing.T) {
 		mock.ExpectExec("INSERT INTO `test`").WithArgs(1, tm, tm).WillReturnError(errors.New("insert error"))
 		mock.ExpectRollback()
 
-		if err := Transaction(db, func(tx *sqlx.Tx) error {
+		if err := Transaction(context.Background(), nil, db, func(tx *sqlx.Tx) error {
 			builder := NewBuilder(tx)
 			builder.SetTime(&tm)
 			_, err := builder.Insert().Exec(ctx, &test.TestSchema{Foo: 1, Bar: 2})


### PR DESCRIPTION
Use BeginTxx instead of Beingx to get spans. Beingx doesn't treat context object. Therefore we can't get trace of Begin, Commit and Rollback queries because of the torm depends on the `Beginx` function.